### PR TITLE
Add cedilla to UK intl. with dead keys

### DIFF
--- a/symbols/gb
+++ b/symbols/gb
@@ -54,6 +54,8 @@ xkb_symbols "intl" {
     key <BKSL>  { [ numbersign, dead_tilde,            bar,         bar ] };
     key <LSGT>  { [  backslash,        bar,            bar,         bar ] };
 
+    key <AB08>  { [      comma,       less,       ccedilla,         Ccedilla ] };
+
     include "level3(ralt_switch)"
 };
 


### PR DESCRIPTION
AltGr+, used to map to comma, which is already available by simply typing comma. Before this change, there was no way to output a cedilla from the UK intl. keyboard.

The cedilla is important for Portuguese (one of the top 10 biggest languages in the world). So much so, that the US intl.  already maps AltGr+, to cedilla. This patch implements the same feature in the UK intl. keyboad.