### PR TITLE
add Microsoft Windows Persian layout

### DIFF
--- a/symbols/ir
+++ b/symbols/ir
@@ -36,6 +36,81 @@ xkb_symbols "pes_keypad" {
     include "level3(ralt_switch)"
 };
 
+////////////////////////////////////////
+// Microsoft windows Persian layout 
+// by github.com/SeniorHunter
+/////
+
+partial alphanumeric_keys
+xkb_symbols "pes_windows" {
+    name[Group1]= "Persian (windows)";
+    
+    include "ir(pes_part_basic_win)"
+    include "ir(pes_part_ext)"
+
+    include "nbsp(zwnj2nb3nnb4)"
+    include "level3(ralt_switch)"
+};
+
+hidden partial alphanumeric_keys
+xkb_symbols "pes_part_basic_win" {
+
+    // Persian digits
+    key <TLDE> {    [ 0x100200d,	division,	asciitilde	] };
+    key <AE01> {	[	  Farsi_1,	exclam 		]	};
+    key <AE02> {	[	  Farsi_2,	at		    ]	};
+    key <AE03> {	[	  Farsi_3,	numbersign	]	};
+    key <AE04> {	[	  Farsi_4,	dollar		]	};
+    key <AE05> {	[	  Farsi_5,	percent		]	};
+    key <AE06> {	[	  Farsi_6,	asciicircum	]	};
+    key <AE07> {	[	  Farsi_7,	ampersand	]	};
+    key <AE08> {	[	  Farsi_8,	asterisk	]	};
+    key <AE09> {	[	  Farsi_9,	parenleft	]	};
+    key <AE10> {	[	  Farsi_0,	parenright	]	};
+    key <AE11> {	[     minus,	underscore	]	};
+    key <AE12> {	[     equal,	plus		]	};
+
+    // Persian letters and symbols
+    key <AD01> { [ Arabic_dad,		Arabic_fathatan,		degree		] };
+    key <AD02> { [ Arabic_sad,		Arabic_dammatan,	VoidSymbol	] };
+    key <AD03> { [ Arabic_theh,		Arabic_kasratan,	0x13a4		] };
+    key <AD04> { [ Arabic_qaf,		0x100fdfc,	VoidSymbol	] };
+    key <AD05> { [ Arabic_feh,		Arabic_comma,		VoidSymbol	] };
+    key <AD06> { [ Arabic_ghain,	Arabic_semicolon,		VoidSymbol	] };
+    key <AD07> { [ Arabic_ain,		comma,		VoidSymbol	] };
+    key <AD08> { [ Arabic_heh,		bracketright,		0x100202d	] };
+    key <AD09> { [ Arabic_khah,		bracketleft,		0x100202e	] };
+    key <AD10> { [ Arabic_hah,		backslash,		0x100202c	] };
+    key <AD11> { [ Arabic_jeem,		braceright,		0x100202a	] };
+    key <AD12> { [ Arabic_tcheh,	braceleft,		0x100202b	] };
+
+    key <AC01> { [ Arabic_sheen,	Arabic_fatha,	VoidSymbol	] };
+    key <AC02> { [ Arabic_seen,		Arabic_damma,	VoidSymbol	] };
+    key <AC03> { [ Farsi_yeh,		Arabic_kasra,		Arabic_alefmaksura ] };
+    key <AC04> { [ Arabic_beh,		Arabic_shadda,	VoidSymbol	] };
+    key <AC05> { [ Arabic_lam,		Arabic_hamzaonalef,	VoidSymbol	] };
+    key <AC06> { [ Arabic_alef,		Arabic_maddaonalef,	0x1000671	] };
+    key <AC07> { [ Arabic_teh,		Arabic_tehmarbuta,	VoidSymbol	] };
+    key <AC08> { [ Arabic_noon,		guillemotright,		0x100fd3e	] };
+    key <AC09> { [ Arabic_meem,		guillemotleft,		0x100fd3f	] };
+    key <AC10> { [ Arabic_keheh,	colon,			semicolon	] };
+    key <AC11> { [ Arabic_gaf,		quotedbl,	quotedbl	] };
+
+    key <AB01> { [ Arabic_zah,		Arabic_tehmarbuta,		VoidSymbol	] };
+    key <AB02> { [ Arabic_tah,		Arabic_yeh,		VoidSymbol	] };
+    key <AB03> { [ Arabic_zain,		Arabic_jeh,		VoidSymbol	] };
+    key <AB04> { [ Arabic_ra,		Arabic_hamzaonwaw,0x1000656	] };
+    key <AB05> { [ Arabic_thal,		0x100200c,		0x100200d	] };
+    key <AB06> { [ Arabic_dal,		Arabic_hamza_above,	Arabic_hamza_below	] };
+    key <AB07> { [ Arabic_peh,		Arabic_hamzaonyeh,		ellipsis	] };
+    key <AB08> { [ Arabic_waw,		greater,		comma		] };
+    key <AB09> { [ period,		less,			apostrophe	] };
+    key <AB10> { [ slash,		Arabic_question_mark,	question	] };
+
+    key <BKSL> { [ Arabic_peh,		bar,			0x1002010	] };
+};
+
+
 hidden partial alphanumeric_keys
 xkb_symbols "pes_part_basic" {
 


### PR DESCRIPTION
It was always a problem for myself so I create a Microsoft Persian layout.
this is not a standard Persian keyboard, but most of the computers in Iran use this keyboard map so its a little hard for the people migrating from Windows to use the new keyboard