### PR TITLE
Adding symbols, numbers, and punctuation to Israeli phonetic keymap

### DIFF
--- a/symbols/il
+++ b/symbols/il
@@ -145,7 +145,29 @@ xkb_symbols "phonetic" {
 
     name[Group1]= "Hebrew (phonetic)";
 
-    key <AE12> {        [     equal,    plus, hebrew_doublelowline, hebrew_doublelowline ]};
+    key <TLDE> {	[     grave,	asciitilde	]	};
+    key <AE01> {	[	  1,	exclam 		]	};
+    key <AE02> {	[	  2,	at		]	};
+    key <AE03> {	[	  3,	numbersign	]	};
+    key <AE04> {	[	  4,	dollar		]	};
+    key <AE05> {	[	  5,	percent		]	};
+    key <AE06> {	[	  6,	asciicircum	]	};
+    key <AE07> {	[	  7,	ampersand	]	};
+    key <AE08> {	[	  8,	asterisk	]	};
+    key <AE09> {	[	  9,	parenleft	]	};
+    key <AE10> {	[	  0,	parenright	]	};
+    key <AE11> {	[     minus,	underscore	]	};
+    key <AE12> {	[     equal,	plus		]	};
+
+    key <AD11> {	[ bracketleft,	braceleft	]	};
+    key <AD12> {	[ bracketright,	braceright	]	};
+    key <AC10> {	[ semicolon,	colon		]	};
+    key <AC11> {	[ apostrophe,	quotedbl	]	};
+    key <AB08> {	[     comma,	less		]	};
+    key <AB09> {	[    period,	greater		]	};
+    key <AB10> {	[     slash,	question	]	};
+    key <BKSL> {	[ backslash,         bar	]	};
+
 
     key <LatQ> {	[ hebrew_qoph, hebrew_qoph	]	};
     key <LatW> {	[ hebrew_waw, hebrew_waw	]	};


### PR DESCRIPTION
The il(phonetic) key map contains all of the Hebrew letters, but is noticeably missing numbers, symbols, and punctuation marks. This effectively makes it impossible to use the il(phonetic) key map for anything other than typing words or individual letters.

This change lifts the numbers, symbols, and punctuation from the standard US keymap, adding to this keymap.  Now I can type sentences!