### PR TITLE
Remove inappropriate compose key from gb(colemak)

### DIFF
--- a/symbols/gb
+++ b/symbols/gb
@@ -118,7 +118,7 @@ xkb_symbols "colemak" {
     key <BKSL>	{ [numbersign, asciitilde,   dead_grave,   dead_breve ]	};
     key <LSGT>	{ [ backslash,        bar,          bar,    brokenbar ]	};
 
-    include "level3(ralt_switch_multikey)"
+    include "level3(ralt_switch)"
 };
 
 


### PR DESCRIPTION
Remove [Shift+Right Alt](https://manpages.debian.org/testing/xkb-data/xkeyboard-config.7.en.html#Key_to_choose_the_3rd_level) as Compose key. Makes consistent with [us(colemak)](https://github.com/freedesktop/xkeyboard-config/blob/77f114a12494c88fd8c9b144ec12f53e9677fedb/symbols/us#L796)

Colemak layouts intends AltGr as dead key; there is no compose key. https://colemak.com/Multilingual

Fixes google/extra-keyboards-for-chrome-os#86