### PR TITLE
"the Ukraine" → Ukraine

### DIFF
--- a/symbols/ua
+++ b/symbols/ua
@@ -1,4 +1,4 @@
-// Keyboard layouts for the Ukraine.
+// Keyboard layouts for Ukraine
 // AEN <aen@logic.ru> & Leon Kanter <leon@geon.donetsk.ua>
 // last changes 2007/10/03 by Andriy Rysin <arysin@yahoo.com>
 


### PR DESCRIPTION
[It’s Ukraine, not ‘the’ Ukraine. And Ukrainians want you to get it right.](https://www.washingtonpost.com/world/2019/10/01/its-ukraine-not-ukraine-ukrainians-want-you-get-it-right/)