### PR TITLE
Add South Azerbaijani layout.

### DIFF
--- a/rules/base.xml
+++ b/rules/base.xml
@@ -1820,6 +1820,12 @@
             <description>Azerbaijani (Cyrillic)</description>
           </configItem>
         </variant>
+        <variant>
+          <configItem>
+            <name>azb</name>
+            <description>Azerbaijani (Iran)</description>
+          </configItem>
+        </variant>
       </variantList>
     </layout>
     <layout>

--- a/symbols/az
+++ b/symbols/az
@@ -85,3 +85,67 @@ xkb_symbols "cyrillic" {
   key <AB09> {[ Cyrillic_o_bar,    Cyrillic_O_bar     ] };
   key <AB10> {[ period,            comma              ] };
 };
+
+// Symbols definition for South Azerbaijani keyboard layout.
+// 2022 - Alborz Jafari <alborz.jf@gmail.com>
+
+partial default alphanumeric_keys
+xkb_symbols "azb"
+{
+  name[Group1] = "azb";
+    // South Azerbaijani digits
+    key <AE01> { [ Farsi_1,          exclam,                  grave              ] };
+    key <AE02> { [ Farsi_2,          0x100066c,               at                 ] };
+    key <AE03> { [ Farsi_3,          0x100066b,               numbersign         ] };
+    key <AE04> { [ Farsi_4,          0x100fdfc,               dollar             ] };
+    key <AE05> { [ Farsi_5,          0x100066a,               percent            ] };
+    key <AE06> { [ Farsi_6,          multiply,                asciicircum        ] };
+    key <AE07> { [ Farsi_7,          Arabic_comma,            ampersand          ] };
+    key <AE08> { [ Farsi_8,          asterisk,                enfilledcircbullet ] };
+    key <AE09> { [ Farsi_9,          parenright,              0x100200e          ] };
+    key <AE10> { [ Farsi_0,          parenleft,               0x100200f          ] };
+
+    // South Azerbaijani letters and symbols
+    key <AD01> { [ Arabic_dad,       U06C7,                   degree             ] };
+    key <AD02> { [ Arabic_sad,       U06C6,                   Arabic_dammatan    ] };
+    key <AD03> { [ Arabic_theh,      Arabic_kasratan,         U0652              ] };
+    key <AD04> { [ Arabic_qaf,       Arabic_fathatan,         VoidSymbol         ] };
+    key <AD05> { [ Arabic_feh,       Arabic_damma,            VoidSymbol         ] };
+    key <AD06> { [ Arabic_ghain,     Arabic_kasra,            VoidSymbol         ] };
+    key <AD07> { [ Arabic_ain,       Arabic_fatha,            VoidSymbol         ] };
+    key <AD08> { [ Arabic_heh,       Arabic_shadda,           0x100202d          ] };
+    key <AD09> { [ Arabic_khah,      bracketright,            0x100202e          ] };
+    key <AD10> { [ Arabic_hah,       bracketleft,             0x100202c          ] };
+    key <AD11> { [ Arabic_jeem,      braceright,              0x100202a          ] };
+    key <AD12> { [ Arabic_tcheh,     braceleft,               0x100202b          ] };
+
+    key <AC01> { [ Arabic_sheen,     Arabic_hamzaonwaw,       VoidSymbol         ] };
+    key <AC02> { [ Arabic_seen,      Arabic_hamzaonyeh,       VoidSymbol         ] };
+    key <AC03> { [ Farsi_yeh,        U063D,                   Arabic_alefmaksura ] };
+    key <AC04> { [ Arabic_beh,       Arabic_hamzaunderalef,   VoidSymbol         ] };
+    key <AC05> { [ Arabic_lam,       Arabic_hamzaonalef,      VoidSymbol         ] };
+    key <AC06> { [ Arabic_alef,      Arabic_maddaonalef,      0x1000671          ] };
+    key <AC07> { [ Arabic_teh,       Arabic_tehmarbuta,       VoidSymbol         ] };
+    key <AC08> { [ Arabic_noon,      guillemotright,          0x100fd3e          ] };
+    key <AC09> { [ Arabic_meem,      guillemotleft,           0x100fd3f          ] };
+    key <AC10> { [ Arabic_keheh,     colon,                   semicolon          ] };
+    key <AC11> { [ Arabic_gaf,       Arabic_semicolon,        quotedbl           ] };
+
+    key <AB01> { [ Arabic_zah,       Arabic_kaf,              VoidSymbol         ] };
+    key <AB02> { [ Arabic_tah,       0x1000653,               VoidSymbol         ] };
+    key <AB03> { [ Arabic_zain,      Arabic_jeh,              VoidSymbol         ] };
+    key <AB04> { [ Arabic_ra,        Arabic_superscript_alef, 0x1000656          ] };
+    key <AB05> { [ Arabic_thal,      0x100200c,               0x100200d          ] };
+    key <AB06> { [ Arabic_dal,       Arabic_hamza_above,      Arabic_hamza_below ] };
+    key <AB07> { [ Arabic_peh,       Arabic_hamza,            ellipsis           ] };
+    key <AB08> { [ Arabic_waw,       greater,                 comma              ] };
+    key <AB09> { [ period,           less,                    apostrophe         ] };
+    key <AB10> { [ slash,            Arabic_question_mark,    question           ] };
+
+    key <TLDE> { [ 0x100200d,        division,                asciitilde         ] };
+    key <AE11> { [ minus,            Arabic_tatweel,          underscore         ] };
+    key <AE12> { [ equal,            plus,                    0x1002212          ] };
+    key <BKSL> { [ backslash,        bar,                     0x1002010          ] };
+
+    include "nbsp(zwnj2nb3nnb4)"
+};


### PR DESCRIPTION
This commit adds [South Azerbaijani](https://iso639-3.sil.org/code/azb) layout, this layout uses Arabic alphabet for Azerbaijani language.
This layout has been added to [Gboard](https://play.google.com/store/apps/details?id=com.google.android.inputmethod.latin&hl=en&gl=US) earlier. South Azerbaijani language has a [Wikipedia page](https://azb.wikipedia.org/wiki/%D8%A2%D9%86%D8%A7_%D8%B5%D9%81%D8%AD%D9%87) with more than 240000 pages but there is no layout in Linux for this language.