### PR TITLE
Czech layout following to what is actually printed on the keyboard

### DIFF
--- a/rules/base.extras.xml
+++ b/rules/base.extras.xml
@@ -1046,6 +1046,12 @@
             <description>Czech (US, Colemak, UCW support)</description>
           </configItem>
         </variant>
+        <variant>
+          <configItem popularity="exotic">
+            <name>geekqwerty</name>
+            <description>Czech (Geek QWERTY, Windows flavour)</description>
+          </configItem>
+        </variant>
       </variantList>
     </layout>
     <layout>

--- a/rules/base.xml
+++ b/rules/base.xml
@@ -3222,6 +3222,24 @@
             </languageList>
           </configItem>
         </variant>
+        <variant>
+          <configItem>
+            <name>newqwertz</name>
+            <description>Czech (QWERTZ, Windows flavor)</description>
+          </configItem>
+        </variant>
+        <variant>
+          <configItem>
+            <name>newqwerty</name>
+            <description>Czech (QWERTY, Windows flavor)</description>
+          </configItem>
+        </variant>
+        <variant>
+          <configItem>
+            <name>geekqwerty</name>
+            <description>Czech (Geek QWERTY, Windows flavour)</description>
+          </configItem>
+        </variant>
       </variantList>
     </layout>
     <layout>

--- a/symbols/cz
+++ b/symbols/cz
@@ -331,6 +331,93 @@ xkb_symbols "rus" {
    include "level3(ralt_switch)"
 };
 
+partial alphanumeric_keys
+xkb_symbols "newqwertz" {
+
+    // This layout conforms to the Windows defintion that is slightly different 
+    // to standard ČSN 36 9050, but is printed on every physical keyboard on
+    // the market. This layout is just conventient for all the people who must
+    // work on Windows PC at work, and work on Linux at home.
+    //
+    // 2023 by Milos Kozák <milos.kozak@lejmr.com>
+
+    include "latin"
+    name[Group1]= "Czech (Windows, flavour)";
+
+    key <TLDE>  {[ semicolon, dead_abovering,    grave,   asciitilde ] };
+    key <AE01>  {[      plus,          1,       exclam,   dead_tilde ] };
+    key <AE02>  {[    ecaron,          2,           at,   dead_caron ] };
+    key <AE03>  {[    scaron,          3,   numbersign, dead_circumflex ] };
+    key <AE04>  {[    ccaron,          4,       dollar,   dead_breve ] };
+    key <AE05>  {[    rcaron,          5,      percent, dead_abovering]};
+    key <AE06>  {[    zcaron,          6,  asciicircum,  dead_ogonek ] };
+    key <AE07>  {[    yacute,          7,    ampersand,   dead_grave ] };
+    key <AE08>  {[    aacute,          8,     asterisk, dead_abovedot] };
+    key <AE09>  {[    iacute,          9,    braceleft,   dead_acute ] };
+    key <AE10>  {[    eacute,          0,   braceright, dead_doubleacute ] };
+    key <AE11>  {[     equal,    percent,        minus, underscore]};
+    key <AE12>  {[dead_acute, dead_caron,        equal, plus ] };
+
+    key <AD01>  {[         q,          Q,    backslash,     NoSymbol ] };
+    key <AD02>  {[         w,          W,          bar,     NoSymbol ] };
+    key <AD03>  {[         e,          E,     EuroSign,     NoSymbol ] };
+    key <AD04>  {[         r,          R,     NoSymbol,     NoSymbol ] };
+    key <AD05>  {[         t,          T,     NoSymbol,     NoSymbol ] };
+    key <AD06>  {[         z,          Z,     NoSymbol,     NoSymbol ] };
+    key <AD07>  {[         u,          U,     NoSymbol,     NoSymbol ] };
+    key <AD08>  {[         i,          I,     NoSymbol,     NoSymbol ] };
+    key <AD09>  {[         o,          O,     NoSymbol,     NoSymbol ] };
+    key <AD10>  {[         p,          P,     NoSymbol,     NoSymbol ] };
+    key <AD11>  {[    uacute,      slash,  bracketleft,     braceleft ] };
+    key <AD12>  {[parenright,  parenleft, bracketright,     braceright ] };
+
+    key <AC01>  {[         a,          A,   asciitilde,     NoSymbol ] };
+    key <AC02>  {[         s,          S,      dstroke,     NoSymbol ] };
+    key <AC03>  {[         d,          D,      Dstroke,     NoSymbol ] };
+    key <AC04>  {[         f,          F,  bracketleft,     NoSymbol ] };
+    key <AC05>  {[         g,          G, bracketright,     NoSymbol ] };
+    key <AC06>  {[         h,          H,        grave,     NoSymbol ] };
+    key <AC07>  {[         j,          J,   apostrophe,     NoSymbol ] };
+    key <AC08>  {[         k,          K,      lstroke,     NoSymbol ] };
+    key <AC09>  {[         l,          L,      Lstroke,     NoSymbol ] };
+    key <AC10>  {[     uring,   quotedbl,    semicolon,     colon ] };
+    key <AC11>  {[   section,     exclam,   apostrophe,     quotedbl ] };
+    key <BKSL>  {[dead_diaeresis, apostrophe, backslash,         bar ] };
+
+    key <LSGT>  {[ backslash,        bar,        slash,     NoSymbol ] };
+    key <AB01>  {[         y,          Y,       degree,     NoSymbol ] };
+    key <AB02>  {[         x,          X,   numbersign,     NoSymbol ] };
+    key <AB03>  {[         c,          C,    ampersand,     NoSymbol ] };
+    key <AB04>  {[         v,          V,           at,     NoSymbol ] };
+    key <AB05>  {[         b,          B,    braceleft,     NoSymbol ] };
+    key <AB06>  {[         n,          N,   braceright,     NoSymbol ] };
+    key <AB07>  {[         m,          M,  asciicircum,     NoSymbol ] };
+    key <AB08>  {[     comma,   question,         less,     comma ] };
+    key <AB09>  {[    period,      colon,      greater,     period ] };
+    key <AB10>  {[     minus, underscore,         slash,    question ] };
+
+    key <SPCE>  {[     space,      space,        space,       space  ] };
+
+    include "level3(ralt_switch)"
+};
+
+partial alphanumeric_keys
+xkb_symbols "newqwerty" {
+
+    // This layout conforms to the Windows defintion that is slightly different 
+    // to standard ČSN 36 9050, but is printed on every physical keyboard on
+    // the market. This layout is just conventient for all the people who must
+    // work on Windows PC at work, and work on Linux at home.
+    //
+    // 2023 by Milos Kozák <milos.kozak@lejmr.com>
+
+    include "cz(newqwertz)"
+    name[Group1]= "Czech (QWERTY, Windows flavour)";
+    
+    key <AD06>  {[         y,          Y,     NoSymbol,         NoSymbol ] };
+    key <AB01>  {[         z,          Z,       degree,         NoSymbol ] };
+};
+
 // EXTRAS:
 
 partial alphanumeric_keys
@@ -483,4 +570,22 @@ xkb_symbols "coder" {
     key <BKSL>	{[ backslash,        bar, dead_diaeresis, apostrophe ]};
 
     include "level3(ralt_switch)"
+};
+
+partial alphanumeric_keys
+xkb_symbols "geekqwerty" {
+
+    // This layout conforms to the Windows defintion that is slightly different 
+    // to standard ČSN 36 9050, but is printed on every physical keyboard on
+    // the market. This layout is just conventient for all the people who must
+    // work on Windows PC at work, and work on Linux at home.
+    // This QWERTY modification is unix-friendly.
+    //
+    // 2023 by Milos Kozák <milos.kozak@lejmr.com>
+
+    include "cz(newqwerty)"
+    name[Group1]= "Czech (Geek QWERTY, Windows flavour)";
+
+    key <TLDE>  {[     grave,  asciitilde,      semicolon, dead_abovering ]};
+    key <BKSL>  {[ backslash,         bar, dead_diaeresis, apostrophe ] };   
 };


### PR DESCRIPTION
This is what a typical Czech keyboard looks like, [link](https://cdn.alza.cz/ImgW.ashx?fd=f4&cd=ADP2c014&i=1.jpg). It is different compared to layout defined by [ČSN 369050](http://www.ceskaklavesnice.cz/rozlozeni) standard. 

Currently, this repository provides "basic" layout following the standard, and "qwerty" which modifies the "basic" to something similar to what is on today's market. 

This PR brings what is on the market.

I named those layouty as Windows flavout since Windows has got the same layout to what is on the market.